### PR TITLE
Fix "Live Photos" failing to attach to an iMessage -> Matrix message

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,6 @@ const {
   utils: { download }
 } = require("matrix-puppet-bridge");
 const puppet = new Puppet('./config.json');
-const sizeOf = require('image-size');
-const mime = require('mime-types');
 const findAttachment = require('./src/find-attachment');
 
 class App extends MatrixPuppetBridgeBase {
@@ -73,15 +71,7 @@ class App extends MatrixPuppetBridgeBase {
         return Promise.map(files, (file)=>{
           return findAttachment(file.id, file.name).then(filepath=>{
             payload.path = filepath;
-            payload.mimetype = mime.lookup(payload.path);
-            if ( payload.mimetype.match(/^image/) ) {
-              const dim = sizeOf(payload.path);
-              payload.h = dim.height;
-              payload.w = dim.width;
-              return this.handleThirdPartyRoomImageMessage(payload);
-            } else {
-              return this.sendStatusMsg({}, "dont know how to deal with filetype", payload);
-            }
+            return this.handleThirdPartyRoomMessageWithAttachment(payload);
           });
         });
       } else {

--- a/package.json
+++ b/package.json
@@ -17,15 +17,13 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "JSONStream": "^1.3.0",
-    "bluebird": "^3.4.7",
+    "JSONStream": "^1.3.5",
+    "bluebird": "^3.5.4",
     "chokidar": "^1.6.1",
-    "image-size": "^0.5.1",
-    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#decce78",
-    "mime-types": "^2.1.15",
-    "moment": "^2.17.1",
+    "matrix-puppet-bridge": "../matrix-puppet-bridge",
+    "moment": "^2.24.0",
     "node-persist": "^2.0.7",
-    "queue": "^4.0.1"
+    "queue": "^4.5.1"
   },
   "devDependencies": {
     "eslint": "^3.12.2"

--- a/src/find-attachment.js
+++ b/src/find-attachment.js
@@ -4,7 +4,7 @@ const config = require('../config.json');
 
 module.exports = function(id, name) {
   return new Promise(function(resolve, reject) {
-    exec(`find ${config.attachmentsDir}/*/*/${name}/*`, function(err, stdout, stderr) {
+    exec(`find ${config.attachmentsDir}/*/*/${name}/${id}`, function(err, stdout, stderr) {
       if (err) {
         console.error(stderr);
         return reject(err);


### PR DESCRIPTION
Fixes #13. 

When ichat2json finds a file attachment it gives us `name`, which is the directory the attachment is in, and `id`, which is the name of the file itself. Weird way to name it, but apparently that's how it's encoded. It looks like a new directory is spawned for every new attachment, so in the case of a simple photo or video we'd just search for the directory and return the file path for whatever was in it. The `id` (filename) was never actually used.

In the case of a live photo, a `.MOV` file and a `.jpeg` appear in the directory at the same time, so using `find` with only the parent directory returns a multi-line string with paths to both files, and the bridge just errors out. This fixes that by searching for the `jpeg` file explicitly and returning the path to only that file.

Note that "live photos" come through as just a photo. In theory we could attach both the `jpeg` file and the `mov` file to preserve some of the live-ness(?) of the photo. Or maybe send the video and use the jpgeg as the thumbnail. I couldn't possibly care less about that, but if someone wants to play around with it, there you go.

I've tested this, it seems fine, but maybe someone else wants to test before merging.