### PR TITLE
fix puppeting by adding aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,6 +191,7 @@ new Cli({
       reg.setAppServiceToken(AppServiceRegistration.generateToken());
       reg.setSenderLocalpart("imessagebot");
       reg.addRegexPattern("users", "@imessage_.*", true);
+      reg.addRegexPattern("aliases", "#imessage_.*", true);
       callback(reg);
     }).catch(err=>{
       console.error(err.message);


### PR DESCRIPTION
This has become a mandatory parameter for puppet bridges. Otherwise messages will be rejected by matrix / matrix-puppet.