### PR TITLE
Avoid exceptions at sendReadReceiptAsPuppetToThirdPartyRoomWithId

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,11 @@ class App extends MatrixPuppetBridgeBase {
     });
   }
 
+  sendReadReceiptAsPuppetToThirdPartyRoomWithId() {
+    //this does nothing but avoiding exceptions :)
+  }
+
+
   handleMatrixUserBangCommand(bangCmd, matrixMsgEvent) {
     const { bangcommand, command, body } = bangCmd;
     const { room_id } = matrixMsgEvent;


### PR DESCRIPTION
Currently the function sendReadReceiptAsPuppetToThirdPartyRoomWithId is called when you read a message. Unfortunately this function is not present, so this results in an exception.

Adding the dummy fixes this until a proper function is implemented. 