### PR TITLE
Handle incoming video/audio/file attachments. Fix various issues with image attachements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,6 @@ const {
   utils: { download }
 } = require("matrix-puppet-bridge");
 const puppet = new Puppet('./config.json');
-const sizeOf = require('image-size');
-const mime = require('mime-types');
 const findAttachment = require('./src/find-attachment');
 
 class App extends MatrixPuppetBridgeBase {
@@ -73,15 +71,7 @@ class App extends MatrixPuppetBridgeBase {
         return Promise.map(files, (file)=>{
           return findAttachment(file.id, file.name).then(filepath=>{
             payload.path = filepath;
-            payload.mimetype = mime.lookup(payload.path);
-            if ( payload.mimetype.match(/^image/) ) {
-              const dim = sizeOf(payload.path);
-              payload.h = dim.height;
-              payload.w = dim.width;
-              return this.handleThirdPartyRoomImageMessage(payload);
-            } else {
-              return this.sendStatusMsg({}, "dont know how to deal with filetype", payload);
-            }
+            return this.handleThirdPartyRoomMessageWithAttachment(payload);
           });
         });
       } else {

--- a/package.json
+++ b/package.json
@@ -17,15 +17,13 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "JSONStream": "^1.3.0",
-    "bluebird": "^3.4.7",
+    "JSONStream": "^1.3.5",
+    "bluebird": "^3.5.4",
     "chokidar": "^1.6.1",
-    "image-size": "^0.5.1",
-    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#decce78",
-    "mime-types": "^2.1.15",
-    "moment": "^2.17.1",
+    "matrix-puppet-bridge": "matrix-hacks/matrix-puppet-bridge#c16ac9f",
+    "moment": "^2.24.0",
     "node-persist": "^2.0.7",
-    "queue": "^4.0.1"
+    "queue": "^4.5.1"
   },
   "devDependencies": {
     "eslint": "^3.12.2"

--- a/src/find-attachment.js
+++ b/src/find-attachment.js
@@ -4,7 +4,7 @@ const config = require('../config.json');
 
 module.exports = function(id, name) {
   return new Promise(function(resolve, reject) {
-    exec(`find ${config.attachmentsDir}/*/*/${name}/${id}`, function(err, stdout, stderr) {
+    exec(`find ${config.attachmentsDir}/*/*/"${name}"/"${id}"`, function(err, stdout, stderr) {
       if (err) {
         console.error(stderr);
         return reject(err);

--- a/src/find-attachment.js
+++ b/src/find-attachment.js
@@ -4,7 +4,7 @@ const config = require('../config.json');
 
 module.exports = function(id, name) {
   return new Promise(function(resolve, reject) {
-    exec(`find ${config.attachmentsDir}/*/*/${name}/*`, function(err, stdout, stderr) {
+    exec(`find ${config.attachmentsDir}/*/*/${name}/${id}`, function(err, stdout, stderr) {
       if (err) {
         console.error(stderr);
         return reject(err);


### PR DESCRIPTION
This refactors the attachment handling to use `handleThirdPartyRoomMessageWithAttachment` that is now part of `matrix-puppet-bridge` as of [this PR](https://github.com/matrix-hacks/matrix-puppet-bridge/pull/53). This means that images, videos, audio clips, and files coming from the iMessage side should be handled and embedded in Matrix properly. Note that `ffmpeg` has to be available in `$PATH` for messages to be sent as `m.video`. If not they'll be sent as file attachments.

There are also changes to the `find-attachment` script. It fixes two things:
1. Filenames with spaces in them no longer fail to send.
2. When sending live photos, a video file and an image file appear in the directory at the same time, which would cause the find script to return a multi-line string and the message would fail to send.

Side Note: The "live photos" come through as just a photo. In theory we could attach both the jpeg file and the mov file to preserve some of the live-ness(?) of the photo. Or maybe send the video and use the jpgeg as the thumbnail. Personally I don't care too much about that, but it's an idea for anyone who does.

This would close #12 and #13.