### PR TITLE
Get clean sender names

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -3,6 +3,7 @@
   "ichatArchives": "~/Library/Containers/com.apple.iChat/Data/Library/Messages/Archive/**/*.ichat",
   "attachmentsDir": "~/Library/Messages/Attachments",
   "port": 8090,
+  "osLanguage": "en",
   "bridge": {
     "homeserverUrl":"https://yourserver.com",
     "domain": "yourserver.com",

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const puppet = new Puppet('./config.json');
 const sizeOf = require('image-size');
 const mime = require('mime-types');
 const findAttachment = require('./src/find-attachment');
+const localSeperators = new Map();
 
 class App extends MatrixPuppetBridgeBase {
   getServicePrefix() {
@@ -25,11 +26,14 @@ class App extends MatrixPuppetBridgeBase {
     this.roomData = {};
     this.client = new Client();
     this.client.on('message', m => this.handleThirdPartyClientMessage(m));
+
+    localSeperators.set('en', ' at ');
+    localSeperators.set('de', ' am ');
+
     return this.client.init(config.ichatArchives);
   }
   handleThirdPartyClientMessage(msg) {
     const {
-      fileRecipient,
       senderIsMe,
       sender,
       subject, //can be null, e.g. if multi-party chat
@@ -39,8 +43,12 @@ class App extends MatrixPuppetBridgeBase {
       isMultiParty,
       participantIds
     } = msg;
-
+    
     let message = msg.message || ""; // yea it can come as null from ichat2json
+    let fileRecipient = msg.fileRecipient;
+    if(localSeperators.has(config.osLanguage)) { // remove date and time provided in sender name
+      fileRecipient = fileRecipient.split(localSeperators.get(config.osLanguage))[0]; 
+    }
 
     console.log('handling message', msg);
 


### PR DESCRIPTION
Cut off sender names after the language specific word before the timestamp. 

Goal:
Turn this: "FirstName at 2019-08-04 1.24.52 AM.ichat"
into this: "Niklas Reimer"

This requires your OS language to be set in the config.json. 