### PR TITLE
Read Receipts iMessage -> Matrix

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ class App extends MatrixPuppetBridgeBase {
     this.roomData = {};
     this.client = new Client();
     this.client.on('message', m => this.handleThirdPartyClientMessage(m));
+    this.client.on('read', m => this.setMessageRead(m));
     return this.client.init(config.ichatArchives);
   }
   handleThirdPartyClientMessage(msg) {
@@ -44,8 +45,6 @@ class App extends MatrixPuppetBridgeBase {
     let message = msg.message || ""; // yea it can come as null from ichat2json
 
     console.log('handling message', msg);
-
-    console.log('read = ', isRead);
 
     let roomId;
     if (chatId && chatId.length > 0) {
@@ -113,6 +112,11 @@ class App extends MatrixPuppetBridgeBase {
       console.error(err.stack);
     });
   }
+
+  setMessageRead(msg) {
+    console.log("mark message as read");
+  }
+
   getThirdPartyRoomDataById(id) {
     return this.roomData[id];
   }

--- a/index.js
+++ b/index.js
@@ -37,12 +37,15 @@ class App extends MatrixPuppetBridgeBase {
       files,
       chatId,
       isMultiParty,
-      participantIds
+      participantIds,
+      isRead
     } = msg;
 
     let message = msg.message || ""; // yea it can come as null from ichat2json
 
     console.log('handling message', msg);
+
+    console.log('read = ', isRead);
 
     let roomId;
     if (chatId && chatId.length > 0) {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ class App extends MatrixPuppetBridgeBase {
     this.roomData = {};
     this.client = new Client();
     this.client.on('message', m => this.handleThirdPartyClientMessage(m));
-    this.client.on('read', m => this.setMessageRead(m));
+
+    this.receiptHistory = new Map();
+    this.client.on('read', m => this.handleReadReceipt(m));
     return this.client.init(config.ichatArchives);
   }
   handleThirdPartyClientMessage(msg) {
@@ -36,8 +38,7 @@ class App extends MatrixPuppetBridgeBase {
       files,
       chatId,
       isMultiParty,
-      participantIds,
-      isRead
+      participantIds
     } = msg;
 
     let message = msg.message || ""; // yea it can come as null from ichat2json
@@ -103,8 +104,39 @@ class App extends MatrixPuppetBridgeBase {
     });
   }
 
-  setMessageRead(msg) {
+  async handleReadReceipt(msg) {
     console.log("mark message as read");
+    try {
+      const {
+        senderIsMe,
+        sender,
+        subject, //can be null, e.g. if multi-party chat
+        chatId
+      } = msg;
+      let roomId;
+      if (chatId && chatId.length > 0) {
+        // this is a multi-party or group chat
+        roomId = chatId;
+      } else {
+        // this is a 1 on 1 chat
+        roomId = senderIsMe ? subject : sender;
+      }
+      if(!this.receiptHistory.has(roomId)) {
+        console.log("no send event found, returning");
+        return;
+      }
+      const event = this.receiptHistory.get(roomId);
+      const ghostIntent = await this.getIntentFromThirdPartySenderId(sender);
+      const matrixRoomId = await this.getOrCreateMatrixRoomFromThirdPartyRoomId(roomId);
+      // HACK: copy from matrix-appservice-bridge/lib/components/indent.js
+      // client can get timeout value, but intent does not support this yet.
+      await ghostIntent._ensureJoined(matrixRoomId);
+      await ghostIntent._ensureHasPowerLevelFor(matrixRoomId, "m.read");
+      ghostIntent.client.sendReadReceipt (event);
+      return this.receiptHistory.delete(roomId);      
+    } catch (err) {
+      debug('could not send read event', err.message);
+    }
   }
 
   getThirdPartyRoomDataById(id) {
@@ -139,6 +171,9 @@ class App extends MatrixPuppetBridgeBase {
   }
   sendMessageAsPuppetToThirdPartyRoomWithId(id, text, matrixEvent) {
     const { sendGroupMessage, sendMessage } = this.client;
+    matrixEvent.getRoomId = () => matrixEvent.room_id;
+    matrixEvent.getId = () => matrixEvent.event_id;
+    this.receiptHistory.set(id, matrixEvent);
     return this.prepareToSend(id, matrixEvent).then(({isGroup, handles, service})=>{
       return isGroup ? sendGroupMessage(handles, text) : sendMessage(id, service, text);
     });

--- a/src/client.js
+++ b/src/client.js
@@ -76,6 +76,7 @@ class Client extends EventEmitter {
                 return storage.getItem(msg.hash).then((meta) => {
                   let shouldSkip = meta && meta.skip;
                   let shouldRelay = !shouldSkip;
+                  let shouldSetRead = meta && shouldSkip && meta.isRead != msg.isRead;
                   if (shouldRelay) {
                     this.emit('message', Object.assign({}, {
                       fileRecipient
@@ -83,10 +84,15 @@ class Client extends EventEmitter {
                   } else {
                     console.log('skiping message: ', msg.sender, msg.message);
                   }
+                  if (shouldSetRead) {
+                    this.emit('read', Object.assign({}, {
+                      fileRecipient
+                    }, msg));
+                  }
                 })
                   .then(()=>{
                     console.log('marking skip: ', msg.hash, msg.sender, msg.message);
-                    return storage.setItem(msg.hash, {skip: true});
+                    return storage.setItem(msg.hash, {skip: true, isRead: msg.isRead});
                   })
                   .catch((err)=>{
                     // poor man's retry


### PR DESCRIPTION
As ichat2json sends isRead for messages we can trigger events if we should mark a message as read.

So we save the corresponding matrix events for our sent messages and  use them if we get read events from the client.