### PR TITLE
Fix crash due to lack of sendTypingEventAsPuppetToThirdPartyRoomWithId implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,6 +191,9 @@ class App extends MatrixPuppetBridgeBase {
     //this does nothing but avoiding exceptions :)
   }
 
+  sendTypingEventAsPuppetToThirdPartyRoomWithId() {
+    //also avoid exceptions
+  }
 
   handleMatrixUserBangCommand(bangCmd, matrixMsgEvent) {
     const { bangcommand, command, body } = bangCmd;


### PR DESCRIPTION
Just an empty function to avoid the exception because I don't know how to send typing events to iMessage. If someone does know, it would be great to add that to the function.